### PR TITLE
partial fix to framebox issue

### DIFF
--- a/inst/extdata/style/Metafix.sty
+++ b/inst/extdata/style/Metafix.sty
@@ -19,7 +19,7 @@
 \newcommand{\code}[1]{\texttt{#1}}
 
 % figure
-\renewcommand{\framebox}[3]{#3}
+\renewcommand{\framebox}[2][]{#2} % allow for one optional argument
 \renewcommand{\textwidth}{\smallskip}
 
 %\renewcommand{\multicolumn}[3]{ #3}


### PR DESCRIPTION
I updated the \renewcommand of \framebox to allow for one optional argument. This will now handle code such as 

    \framebox[\textwidth]{\hfill \raisebox{0in}{\rule{0in}{1in}}
      \includegraphics[scale=0.35]{NN.jpg} \hfill
    }

It is only a partial fix however, as \framebox has two optional arguments. I tried some of the ideas suggested here for handling two optional arguments: https://tex.stackexchange.com/q/29973/21118, but could not get them to work.

\framebox seems to be only used with one argument in the test files, so probably the fix in this PR is enough for most cases. Perhaps you can flag any articles with two optional arguments, or even better, pre-process to remove them, so `\framebox[...][...]{...}` becomes either `\framebox{...}` or \framebox[...]{...}`, whichever is easier. The update in this PR will handle 1 or 0 optional arguments.